### PR TITLE
ci: workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,7 @@
 ---
 name: Test
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/supercaracal/lsolr/security/code-scanning/4](https://github.com/supercaracal/lsolr/security/code-scanning/4)

In general, fix this by adding a `permissions` block that restricts the GITHUB_TOKEN to the minimal scopes needed. Since these jobs only need to read the repository contents (for `actions/checkout`) and do not push or modify anything on GitHub, `contents: read` at the workflow root is sufficient and avoids duplicating configuration for each job.

The best fix without changing existing functionality is:
- Add a root-level `permissions:` block after the `name: Test` line (line 2) and before `on:` (line 3).
- Set it to `contents: read`. This applies to all jobs (`test`, `lint`, `benchmark`, `profile`) because none define their own `permissions` block.

No imports, methods, or other definitions are needed, since this is a YAML workflow configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
